### PR TITLE
Support z3c.formwidget.query.interfaces.IQuerySource

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 - If vocabulary_factory implements z3c.formwidget.query.interfaces.IQuerySource
   try to search in it
   [ale-rt]
+- fix remove all element in multiselection
+  [mamico]
 
 
 1.0b3 (2015-06-12)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.0b4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- If vocabulary_factory implements z3c.formwidget.query.interfaces.IQuerySource
+  try to search in it
+  [ale-rt]
 
 
 1.0b3 (2015-06-12)
@@ -29,4 +31,3 @@ Changelog
 ------------------
 
 * First public release
-

--- a/raptus/autocompletewidget/skins/autocompletewidget/autocompletemulti.pt
+++ b/raptus/autocompletewidget/skins/autocompletewidget/autocompletemulti.pt
@@ -12,6 +12,7 @@
 
     <metal:define define-macro="edit">
       <div metal:use-macro="here/widgets/lines/macros/edit" />
+      <input type="hidden" name="fieldname" value="" tal:attributes="name string:${fieldName}:list" />
       <script type="text/javascript" tal:content="structure python:widget.js(here, fieldName)"></script>
     </metal:define>
 

--- a/raptus/autocompletewidget/widget.py
+++ b/raptus/autocompletewidget/widget.py
@@ -11,6 +11,13 @@ from raptus.autocompletewidget.interfaces import ISearchableVocabulary
 from zope import component
 from zope import schema
 
+try:
+    # Support z3c.formwidget.query vocabulary_factory
+    # that implement IQuerySource
+    from z3c.formwidget.query.interfaces import IQuerySource
+except ImportError:
+    IQuerySource = None
+
 
 class AutocompleteSearch(BrowserView):
 
@@ -43,6 +50,8 @@ class AutocompleteSearch(BrowserView):
                 vocabulary = factory(self.context)
         if ISearchableVocabulary.providedBy(vocabulary):
             results = vocabulary.search(query, self.context)
+        elif IQuerySource is not None and IQuerySource.providedBy(vocabulary):
+            results = [(x.value, x.title) for x in vocabulary.search(query)]
         else:
             query = query.lower()
             vocab = field.Vocabulary(self.context).items()


### PR DESCRIPTION
The use case is to support the vocabulary_factories
that implement IQuerySource.

This is the case for plone.principalsource.Users

With this patch we can add a field like this one:

``` python
    LinesField(
        'users',
        vocabulary_factory=u"plone.principalsource.Users",
        enforceVocabulary=False,
        multiValued=True,
        storage=AnnotationStorage(),
        widget=AutocompleteMultiSelectionWidget(
            label=u"Users",
        ),
    ),

```

and everything works fine.
